### PR TITLE
Fix no such directory found error in daemons--sudo by trimming tempdir

### DIFF
--- a/daemons.el
+++ b/daemons.el
@@ -245,7 +245,7 @@ system you need to specify your own TRAMP path with a privileged user.
 
 e.g. /ssh:me@example.com|sudo:example.com:"
   (unless (daemons--using-tramp-path-p default-directory)
-    (let ((tempdir (daemons--shell-command-to-string "mktemp -d")))
+    (let ((tempdir (string-trim (daemons--shell-command-to-string "mktemp -d"))))
       (cd (format "/sudo::%s" tempdir)))))
 
 (defun daemons--refresh-list ()


### PR DESCRIPTION
This PR fixes a `cd: No such directory found via CDPATH environment variable` error that is caused by a newline in the result of the `(daemons--shell-command-to-string "mktemp -d")` function call on my system (ubuntu 18.04).

Thanks a lot for creating this package!