### PR TITLE
Guard against Warning lines in brew output

### DIFF
--- a/daemons-brew.el
+++ b/daemons-brew.el
@@ -53,7 +53,8 @@
   (thread-last "brew services list"
     (daemons--shell-command-to-string)
     (daemons--split-lines)
-    (cdr)
+    (seq-drop-while (lambda (s) (not (string-match-p "^Name\\W+Status\\W+User\\W+File" s))))
+    (rest)
     (seq-map 'daemons-brew--parse-list-item)))
 
 (defun daemons-brew--list-headers ()


### PR DESCRIPTION
Resolves #25.

Couldn't resist changing the `cdr` call to `rest` to increase clarity of intent...sorry.