### PR TITLE
daemons-brew.el: prefer cdr over rest

### DIFF
--- a/daemons-brew.el
+++ b/daemons-brew.el
@@ -54,7 +54,7 @@
     (daemons--shell-command-to-string)
     (daemons--split-lines)
     (seq-drop-while (lambda (s) (not (string-match-p "^Name\\W+Status\\W+User\\W+File" s))))
-    (rest)
+    (cdr)
     (seq-map 'daemons-brew--parse-list-item)))
 
 (defun daemons-brew--list-headers ()


### PR DESCRIPTION
Whoops, I didn't realize `rest` was from `cl`, not in Elisp core (too much Clojure 🤪). Current state leads to a warning during package installation:

```
In end of data:
daemons-brew.el:57:6: Warning: the function ‘rest’ is not known to be defined.
```

Reverting (8338450a8357f1afc5a9b44198fd2e6659eb1e53) back instead adding a new `require`.