### PR TITLE
Add basic Cask setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cask
 daemons-*/
 *.tar
 \#*\#

--- a/Cask
+++ b/Cask
@@ -1,0 +1,4 @@
+(source gnu)
+(source melpa)
+
+(package-file "daemons.el")

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ $(PACKAGE_NAME).tar: clean $(FILES)
 clean:
 	rm -f $(PACKAGE_NAME).tar
 	rm -rf $(PACKAGE_NAME)
+	rm -rf .cask
+
+compile: cask
+	! (cask eval "(let ((byte-compile-error-on-warn t)) \
+	                 (cask-cli/build))" 2>&1 \
+	   | egrep -a "(Warning|Error):") ; \
+	  (ret=$$? ; cask clean-elc && exit $$ret)
+
+.PHONY: compile


### PR DESCRIPTION
Any interest in using [Cask](https://github.com/cask/cask)? (No hard feelings if not and you want to just close without merging.)

Cask gives an easy way to have a clean build environment and thus track down compilation warnings and errors which would occur in a clean environment but might not occur in a user's specific configuration (for example, I would have noticed the warning I fixed in #27). Since many packages are so frequently loaded (e.g. `cl`), it can be easy to miss that these things are not universally available.

This PR adds a new make target, `compile`. Current output looks like this, revealing a couple warnings we might want to fix:

```
$ make compile
daemons-brew.el:70:1:Error: the function ‘rest’ is not known to be defined.
daemons.el:427:1:Error: the following functions are not known to be defined: tramp-dissect-file-name, tramp-file-name-user, tramp-file-name-host
make: *** [compile] Error 1
```