### PR TITLE
Add systemd support for eldoc

### DIFF
--- a/README.org
+++ b/README.org
@@ -65,6 +65,8 @@ If for some reason you are unable or prefer not to use MELPA, you can also do th
 
 Please see =M-x customize-mode=.
 
+For ~eldoc~ support (currently ~systemd~ only), you can use ~(add-hook 'daemons-mode-hook eldoc-mode)~.
+
 ** Troubleshooting
 
 Note that the MELPA Stable release is updated very conservatively, so if you have any problem that can't be solved by the below advice, please try reverting the stable version, e.g.:

--- a/daemons-systemd.el
+++ b/daemons-systemd.el
@@ -33,6 +33,26 @@
       "systemctl --user"
     "systemctl"))
 
+(defun daemons--systemd-documentation-for (service)
+  "Return documentation for SERVICE."
+  (let* ((output (shell-command-to-string
+                  (format "systemctl show %s --no-pager" service)))
+         (lines (split-string output "\n"))
+         (prefix "Description=")
+         (desc (seq-find (lambda (s) (string-prefix-p prefix s)) lines)))
+    (when desc
+      (substring desc (length prefix)))))
+
+(defun daemons--systemd-eldoc-function (callback &rest _ignored)
+  "Document service at point by calling CALLBACK."
+  (when-let* ((maybe-service (thing-at-point 'symbol))
+              (line (thing-at-point 'line))
+              ((string= maybe-service (car (split-string (string-trim line)))))
+              (result (daemons--systemd-documentation-for maybe-service)))
+    (funcall callback result
+             :thing maybe-service
+             :face 'font-lock-variable-name-face)))
+
 (daemons-define-submodule daemons-systemd
   "Daemons submodule for systemd."
 
@@ -49,7 +69,9 @@
 
   :list (daemons-systemd--list)
 
-  :headers [("Daemon (service)" 60 t) ("Enabled" 40 t)])
+  :headers [("Daemon (service)" 60 t) ("Enabled" 40 t)]
+
+  :eldoc-documentation-function #'daemons--systemd-eldoc-function)
 
 (defun daemons-systemd--parse-list-item (raw-systemctl-output)
   "Parse a single line from RAW-SYSTEMCTL-OUTPUT into a tabulated list item."


### PR DESCRIPTION
Hi!  This PR adds eldoc support for systemd using the output of `systemctl show`.  The idea is when your cursor is on a particular service, the service description appears in the echo area if available:

![daemons-eldoc1](https://github.com/cbowdon/daemons.el/assets/17688577/e322156a-05cb-472d-a0e3-4d56df5535c1)
![daemons-eldoc2](https://github.com/cbowdon/daemons.el/assets/17688577/4b2303ae-448b-457f-a127-ed39f808d46d)
(print screen doesn't show cursor unfortunately)

Noteworthy:

- Currently obtaining the doc is not asynchronous, though I haven't encountered any performance issues
- Deciding whether to trigger eldoc on a given tabulated list entry is a bit hacky (AFAICS there's no way to get the tabulated list column at point?)
- I saw that `daemons` still supports Emacs `25`, so I've added the `compat` library (to use `when-let*` and friends) - I hope this is ok