### PR TITLE
Fix documentation regarding enable/disable commands in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ The following commands are available for each daemon:
 | =daemons-enable=  | e                       |
 | =daemons-disable= | d                       |
 
-/Sorry I've only implemented =enable= and =disable= for systemd so far - raise an issue if you want support for your system!/
+/Sorry, =enable= and =disable= have only been implemented for systemd and GNU Shepherd so far - raise an issue if you want support for your system!/
 
 Results of commands are displayed in a =special-mode= buffer, in which the same commands are available for the selected daemon. So you can (for example) keep reloading the same daemon with =r= without having to re-select it.
 


### PR DESCRIPTION
Hi, Chris - nice Emacs package! Here's a quick PR fo update a line in the README.

The README initially read that `enable` and `disable` commands were only available in systemd, but I see that they're actually available in GNU Shepherd, too. Submitting this quick edit, as I went down the rabbit hole to see if I could add the commands to GNU Shepherd (I'm on Guix SD), only to find that they're already implemented!